### PR TITLE
Download zip fails when file counts exceed the limit

### DIFF
--- a/src/main/java/uk/ac/ebi/biostudies/config/MyTomcatConnectorCustomizer.java
+++ b/src/main/java/uk/ac/ebi/biostudies/config/MyTomcatConnectorCustomizer.java
@@ -1,0 +1,17 @@
+package uk.ac.ebi.biostudies.config;
+
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Configuration
+@Component
+public class MyTomcatConnectorCustomizer implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers(connector -> connector.setMaxParameterCount(100000));
+    }
+}

--- a/src/main/java/uk/ac/ebi/biostudies/config/MyTomcatConnectorCustomizer.java
+++ b/src/main/java/uk/ac/ebi/biostudies/config/MyTomcatConnectorCustomizer.java
@@ -1,17 +1,22 @@
 package uk.ac.ebi.biostudies.config;
 
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Configuration
 @Component
 public class MyTomcatConnectorCustomizer implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    @Autowired
+    private Environment env;
 
     @Override
     public void customize(TomcatServletWebServerFactory factory) {
-        factory.addConnectorCustomizers(connector -> connector.setMaxParameterCount(100000));
+        Integer maxParameterCount = env.getProperty("server.tomcat.max-parameter-count", Integer.class, -1);
+        factory.addConnectorCustomizers(connector -> connector.setMaxParameterCount(maxParameterCount));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,4 +38,5 @@ spring.rabbitmq.listener.simple.auto-startup=false
 
 partial.submission.rabbitmq.queue=submission-submitted-partials-queue
 
+server.tomcat.max-parameter-count=1000000
 


### PR DESCRIPTION
[#178896523]
Threshold increased to 100,000 infinite flag is not recommended for security reasons