### PR TITLE
Ae help update

### DIFF
--- a/src/main/webapp/help/arrayexpress-help.html
+++ b/src/main/webapp/help/arrayexpress-help.html
@@ -43,11 +43,11 @@
     old version of ArrayExpress help page.</a>
 </div>
 
-<p>&nbsp</p>
+<p>&nbsp;</p>
 <h3>How to submit data</h3>
 <p>To submit your functional genomics data to the ArrayExpress collection, go to <a href="https://www.ebi.ac.uk/fg/annotare/login/">Annotare</a> and see the <a href="https://www.ebi.ac.uk/fg/annotare/help/">submission guide</a> for more information about the submission process and how to access privately held data.</p>
 
-<p>&nbsp</p>
+<p>&nbsp;</p>
 <h3>Programmatic access</h3>
 
 <p>Data can be downloaded via FTP or Aspera, following the general instructions for <a href="https://www.ebi.ac.uk/biostudies/help#download">BioStudies data download</a>.</p>
@@ -76,7 +76,6 @@
         BioStudies equivalent is given below. These fields are in addition to the
         <a href="../help#rest-api-docs">default BioStudies search criteria fields</a>.
         Please send all questions and feedback to <a href="mailto://biostudies@ebi.ac.uk">biostudies@ebi.ac.uk</a>.
-        <p>&nbsp</p>
     </dd>
 </dl>
 
@@ -210,7 +209,6 @@
           <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?processed=true</td>
           <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?processed=true</td>
       </tr>
-      </tr>
       <tr>
           <td>assaycount</td>
           <td>assay_count</td>
@@ -304,7 +302,7 @@
 </div>
 </details>
 
-<p>&nbsp</p>
+<p>&nbsp;</p>
 <h3>Learn more about the data in ArrayExpress</h3>
 
 <h4 id="magetab">MAGE-TAB metadata format</h4>
@@ -321,7 +319,7 @@
     <li>A-XXXX-n for array designs</li>
 </ul>
 <p>XXXX represents a four letter code and n is a number. E.g. E-MEXP-568, A-UHNC-18.</p>
-<p>The four letter code in the accession number indicates the data source. Many of the codes are no longer in active use, i.e. they are not used in accession numbers for new submissions, but remain valid. Note that some URLs are dead, or point to webpages which are out of maintenance, but included in the table below for completeness.
+<p>The four letter code in the accession number indicates the data source. Many of the codes are no longer in active use, i.e. they are not used in accession numbers for new submissions, but remain valid. Note that some URLs are dead, or point to webpages which are out of maintenance, but included in the table below for completeness.</p>
 <details>
   <summary>Full list of four-letter codes</summary>
     <table>
@@ -647,7 +645,7 @@
       </tbody>
     </table>
 </details>
-</p>
+
 
 <h4 id="esets">ExpressionSet R objects</h4>
 <p>For many ArrayExpress experiments, an "ExpressionSet" object (e.g. <a href="https://www.ebi.ac.uk/biostudies/files/E-MTAB-777/E-MTAB-777.eSet.r">E-MTAB-777.eSet.r</a>) is available to download for direct loading into <a href="http://www.r-project.org">R</a>.</p>

--- a/src/main/webapp/help/arrayexpress-help.html
+++ b/src/main/webapp/help/arrayexpress-help.html
@@ -13,6 +13,16 @@
         font-size: 10pt;
     }
 
+    details {
+        padding: 10pt;
+    }
+
+    summary {
+        cursor: pointer;
+        padding: 10pt;
+        background-color: #efefef;
+    }
+
     dl dt {
         font-weight: bold;
         font-size: 100%;
@@ -33,9 +43,19 @@
     old version of ArrayExpress help page.</a>
 </div>
 
-<h3>ArrayExpress to BioStudies API Migration Guide</h3>
-<p>We are in the process of migrating ArrayExpress to BioStudies as a collection. As a result, there would be some changes
-    in the API support for ArrayExpress. Until announced, the current version of the API will continue to work. Some major changes are: </p>
+<p>&nbsp</p>
+<h3>How to submit data</h3>
+<p>To submit your functional genomics data to the ArrayExpress collection, go to <a href="https://www.ebi.ac.uk/fg/annotare/login/">Annotare</a> and see the <a href="https://www.ebi.ac.uk/fg/annotare/help/">submission guide</a> for more information about the submission process and how to access privately held data.</p>
+
+<p>&nbsp</p>
+<h3>Programmatic access</h3>
+
+<p>Data can be downloaded via FTP or Aspera, following the general instructions for <a href="https://www.ebi.ac.uk/biostudies/help#download">BioStudies data download</a>.</p>
+<p>The <a href="https://www.ebi.ac.uk/biostudies/help#rest-api-docs">BioStudies API</a> can be used to programmatically search and access all data in the ArrayExpress collection.</p>
+
+<h4 id="api_migration">ArrayExpress to BioStudies API migration guide</h4>
+
+<p>Due to the migration of ArrayExpress to BioStudies as a collection, there will be changes in the API support for ArrayExpress. Until announced, the <a href="https://www.ebi.ac.uk/arrayexpress/help/programmatic_access.html">current version of the API</a> will continue to work. The most important changes are: </p>
 <dl>
     <dt>XML <i class="fas fa-arrow-right"></i> JSON</dt>
     <dd>XML API responses are being deprecated in favour of JSON. However, XML representation is available for
@@ -56,211 +76,213 @@
         BioStudies equivalent is given below. These fields are in addition to the
         <a href="../help#rest-api-docs">default BioStudies search criteria fields</a>.
         Please send all questions and feedback to <a href="mailto://biostudies@ebi.ac.uk">biostudies@ebi.ac.uk</a>.
-        </p>
+        <p>&nbsp</p>
     </dd>
-
 </dl>
-<table>
-    <thead>
-    <tr>
-        <th>Old Field&nbsp;name</th>
-        <th>New Field&nbsp;name</th>
-        <th>What is searched?</th>
-        <th>ArrayExpress Example</th>
-        <th>BioStudies URL</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-        <td>accession</td>
-        <td></td>
-        <td>Experiment primary ArrayExpress or secondary (GEO, ENA, EGA etc) accession</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?accession=E-MEXP-31</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/studies/E-MEXP-31</td>
-    </tr>
-    <tr>
-        <td>array</td>
-        <td>TBD</td>
-        <td>Array design accession or name (wildcards supported)</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?array=A-AFFY-33</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files/A-AFFY-33
-            <a data-open="files-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    <tr>
-        <td>expdesign</td>
-        <td>experimental_design</td>
-        <td>Experiment design type, related to the questions being addressed by the study, e.g. "time series design",
-            "stimulus or stress design", "genetic modification design". Has EFO expansion.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?expdesign=dose+response</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_design="dose response"</td>
-    </tr>
-    <tr>
-        <td>exptype</td>
-        <td>study_type</td>
-        <td>Experiment type, related to the assay technology used. <a href="/arrayexpress/help/experiment_types.html">List of experiment
-            types in ArrayExpress</a>. Has EFO expansion.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?exptype="RNA-seq of non coding RNA"</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?study_type="RNA-seq of non coding RNA"</td>
-    </tr>
-    <tr>
-        <td>ef/ev</td>
-        <td>experimental_factor</td>
-        <td>Experimental factor (also called experimental variable), the name of the main variable under study in an
-            experiment. E.g. if the factor is "sex" in a human study, the researchers would be comparing between male
-            and female samples, and "sex" is not merely an attribute the samples happen to have. Has EFO expansion.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?ef="cell type"</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_factor="cell type"</td>
-    </tr>
-    <tr>
-        <td>efv/evv</td>
-        <td>experimental_factor_value</td>
-        <td>The value of an experimental factor. E.g. The values for "genotype" factor can be "wild type genotype",
-            "p53-/-". Has EFO expansion.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?efv=HeLa</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_factor_value=HeLa</td>
-    </tr>
-    <tr>
-        <td>sa</td>
-        <td>source_characteristics</td>
-        <td>Sample attribute values, e.g. "male", "liver". Has EFO expansion.</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?sa=fibroblast</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?source_characteristics=fibroblast</td>
-    </tr>
-    <tr>
-        <td>sac</td>
-        <td>source_characteristics_value</td>
-        <td>Sample attribute category that is defined in an experiment, e.g. "age", "cell type", "disease". Has EFO
-            expansion.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?sac=age</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?source_characteristics_value=age</td>
-    </tr>
-    <tr>
-        <td>species</td>
-        <td>organism</td>
-        <td>Species of the samples. Can use common name (e.g. "mouse") or binomial nomenclature/Latin names (e.g. "Mus
-            musculus"). Has EFO expansion.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?species="homo sapiens"</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?organism="homo sapien"</td>
-    </tr>
-    <tr>
-        <td>pmid</td>
-        <td></td>
-        <td>PubMed identifier</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?pmid=16553887</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?link_type=pmid&link_value=16553887</td>
-    </tr>
-    <tr>
-        <td>gxa</td>
-        <td>gxa</td>
-        <td>Presence ("true") / absence ("false") of an ArrayExpress experiment in the <a href="/gxa">Expression
-            Atlas</a>.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?gxa=true</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?gxa=true</td>
-    </tr>
-    <tr>
-        <td>directsub</td>
-        <td></td>
-        <td>If "true" only returns experiments directly submitted to ArrayExpress (i.e. not imported from GEO). For more
-            information about how we import data from GEO see the <a href="GEO_data.html">GEO data help page</a>.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?directsub=true</td>
-        <td>TBD</td>
-    </tr>
-    <tr>
-        <td>raw</td>
-        <td>raw</td>
-        <td>Experiment has raw data available.</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?raw=true</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?raw=true</td>
-    </tr>
-    <tr>
-        <td>processed</td>
-        <td>processed</td>
-        <td>Experiment has processed data available.</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?processed=true</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?processed=true</td>
-    </tr>
-    </tr>
-    <tr>
-        <td>assaycount</td>
-        <td>assay_count</td>
-        <td>The number of of assays where x &lt;= y and both values are between 0 and 99,999 (<strong>inclusive</strong>).
-            To count <strong>excluding</strong> the values given use curly brackets e.g. assaycount={1 TO 5} will find
-            experiments with 2-4 assays. Single numbers may also be given e.g. assaycount=10 will find experiments with
-            10 assays.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?assaycount=[1 TO 5]</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?assay_count=[1 TO 5]
-            <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    <tr>
-        <td>samplecount</td>
-        <td>sample_count</td>
-        <td>The number of samples</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?samplecount=[1 TO 5]</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?sample_count=[1 TO 5]
-            <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    <tr>
-        <td>efcount</td>
-        <td>experimental_factor_count</td>
-        <td>The number of experimental factors</td>
-        <td>https://www.ebi.ac.uk/arrayexpressxml/v3/experiments?efcount=[1 TO 5]</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_factor_count=[1 TO 5]
-            <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    <tr>
-        <td>sacount</td>
-        <td></td>
-        <td>The number of sample attribute categories</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?sacount=[1 TO 5]</td>
-        <td>deprecated</td>
-    </tr>
-    <tr>
-        <td>miamescore</td>
-        <td>miame_score</td>
-        <td>The <a href="http://fged.org/projects/miame/">MIAME</a> compliance score (maximum score is 5)</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?miamescore=[1 TO 5]</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?miame_score=[1 TO 5]
-            <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    <tr>
-        <td>minseqe</td>
-        <td>minseqe_score</td>
-        <td>The <a href="http://www.fged.org/projects/minseqe/">MINSEQE</a> compliance score (maximum score is 5)</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?minseqescore=[1 TO 5]</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?minseqe_score=[1 TO 5]
-            <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    <tr>
-        <td>date</td>
-        <td></td>
-        <td>The release date of the experiment. Format is [YYYY-MM-DD]. Wildcards supported. For example:<br>
-            <code>date=2009-12-01</code> will search for experiments released on 1st of Dec 2009.<br>
-            <code>date=2009*</code> will search for experiments released in 2009.<br>
-            <code>date=[2008-01-01 2008-05-31]</code> will search for experiments released between 1st of Jan and end of
-            May 2008.
-        </td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?date=[2008-01-01 2008-05-31]</td>
-        <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?release_date=[2008-01-01 TO 2008-05-31]
-            <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
-        </td>
-    </tr>
-    </tbody>
-</table>
+
+<details>
+  <summary>Full list of field names and equivalents in BioStudies</summary>
+  <table>
+      <thead>
+      <tr>
+          <th>Old Field&nbsp;name</th>
+          <th>New Field&nbsp;name</th>
+          <th>What is searched?</th>
+          <th>ArrayExpress Example</th>
+          <th>BioStudies URL</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+          <td>accession</td>
+          <td></td>
+          <td>Experiment primary ArrayExpress or secondary (GEO, ENA, EGA etc) accession</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?accession=E-MEXP-31</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/studies/E-MEXP-31</td>
+      </tr>
+      <tr>
+          <td>array</td>
+          <td>TBD</td>
+          <td>Array design accession or name (wildcards supported)</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?array=A-AFFY-33</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files/A-AFFY-33
+              <a data-open="files-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      <tr>
+          <td>expdesign</td>
+          <td>experimental_design</td>
+          <td>Experiment design type, related to the questions being addressed by the study, e.g. "time series design",
+              "stimulus or stress design", "genetic modification design". Has EFO expansion.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?expdesign=dose+response</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_design="dose response"</td>
+      </tr>
+      <tr>
+          <td>exptype</td>
+          <td>study_type</td>
+          <td>Experiment type, related to the assay technology used. <a href="/arrayexpress/help/experiment_types.html">List of experiment
+              types in ArrayExpress</a>. Has EFO expansion.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?exptype="RNA-seq of non coding RNA"</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?study_type="RNA-seq of non coding RNA"</td>
+      </tr>
+      <tr>
+          <td>ef/ev</td>
+          <td>experimental_factor</td>
+          <td>Experimental factor (also called experimental variable), the name of the main variable under study in an
+              experiment. E.g. if the factor is "sex" in a human study, the researchers would be comparing between male
+              and female samples, and "sex" is not merely an attribute the samples happen to have. Has EFO expansion.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?ef="cell type"</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_factor="cell type"</td>
+      </tr>
+      <tr>
+          <td>efv/evv</td>
+          <td>experimental_factor_value</td>
+          <td>The value of an experimental factor. E.g. The values for "genotype" factor can be "wild type genotype",
+              "p53-/-". Has EFO expansion.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?efv=HeLa</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_factor_value=HeLa</td>
+      </tr>
+      <tr>
+          <td>sa</td>
+          <td>source_characteristics</td>
+          <td>Sample attribute values, e.g. "male", "liver". Has EFO expansion.</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?sa=fibroblast</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?source_characteristics=fibroblast</td>
+      </tr>
+      <tr>
+          <td>sac</td>
+          <td>source_characteristics_value</td>
+          <td>Sample attribute category that is defined in an experiment, e.g. "age", "cell type", "disease". Has EFO
+              expansion.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/files?sac=age</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?source_characteristics_value=age</td>
+      </tr>
+      <tr>
+          <td>species</td>
+          <td>organism</td>
+          <td>Species of the samples. Can use common name (e.g. "mouse") or binomial nomenclature/Latin names (e.g. "Mus
+              musculus"). Has EFO expansion.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?species="homo sapiens"</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?organism="homo sapien"</td>
+      </tr>
+      <tr>
+          <td>pmid</td>
+          <td></td>
+          <td>PubMed identifier</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?pmid=16553887</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?link_type=pmid&link_value=16553887</td>
+      </tr>
+      <tr>
+          <td>gxa</td>
+          <td>gxa</td>
+          <td>Presence ("true") / absence ("false") of an ArrayExpress experiment in the <a href="/gxa">Expression
+              Atlas</a>.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?gxa=true</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?gxa=true</td>
+      </tr>
+      <tr>
+          <td>directsub</td>
+          <td></td>
+          <td>If "true" only returns experiments directly submitted to ArrayExpress (i.e. not imported from GEO). For more
+              information about how we import data from GEO see the <a href="GEO_data.html">GEO data help page</a>.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?directsub=true</td>
+          <td>TBD</td>
+      </tr>
+      <tr>
+          <td>raw</td>
+          <td>raw</td>
+          <td>Experiment has raw data available.</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?raw=true</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?raw=true</td>
+      </tr>
+      <tr>
+          <td>processed</td>
+          <td>processed</td>
+          <td>Experiment has processed data available.</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?processed=true</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?processed=true</td>
+      </tr>
+      </tr>
+      <tr>
+          <td>assaycount</td>
+          <td>assay_count</td>
+          <td>The number of of assays where x &lt;= y and both values are between 0 and 99,999 (<strong>inclusive</strong>).
+              To count <strong>excluding</strong> the values given use curly brackets e.g. assaycount={1 TO 5} will find
+              experiments with 2-4 assays. Single numbers may also be given e.g. assaycount=10 will find experiments with
+              10 assays.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?assaycount=[1 TO 5]</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?assay_count=[1 TO 5]
+              <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      <tr>
+          <td>samplecount</td>
+          <td>sample_count</td>
+          <td>The number of samples</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?samplecount=[1 TO 5]</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?sample_count=[1 TO 5]
+              <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      <tr>
+          <td>efcount</td>
+          <td>experimental_factor_count</td>
+          <td>The number of experimental factors</td>
+          <td>https://www.ebi.ac.uk/arrayexpressxml/v3/experiments?efcount=[1 TO 5]</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?experimental_factor_count=[1 TO 5]
+              <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      <tr>
+          <td>sacount</td>
+          <td></td>
+          <td>The number of sample attribute categories</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?sacount=[1 TO 5]</td>
+          <td>deprecated</td>
+      </tr>
+      <tr>
+          <td>miamescore</td>
+          <td>miame_score</td>
+          <td>The <a href="http://fged.org/projects/miame/">MIAME</a> compliance score (maximum score is 5)</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?miamescore=[1 TO 5]</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?miame_score=[1 TO 5]
+              <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      <tr>
+          <td>minseqe</td>
+          <td>minseqe_score</td>
+          <td>The <a href="http://www.fged.org/projects/minseqe/">MINSEQE</a> compliance score (maximum score is 5)</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?minseqescore=[1 TO 5]</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?minseqe_score=[1 TO 5]
+              <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      <tr>
+          <td>date</td>
+          <td></td>
+          <td>The release date of the experiment. Format is [YYYY-MM-DD]. Wildcards supported. For example:<br>
+              <code>date=2009-12-01</code> will search for experiments released on 1st of Dec 2009.<br>
+              <code>date=2009*</code> will search for experiments released in 2009.<br>
+              <code>date=[2008-01-01 2008-05-31]</code> will search for experiments released between 1st of Jan and end of
+              May 2008.
+          </td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/experiments?date=[2008-01-01 2008-05-31]</td>
+          <td class="api"><span class="opt">&lt;endpoint&gt;</span>/search?release_date=[2008-01-01 TO 2008-05-31]
+              <a data-open="range-help"><i class="fa fa-info-circle"></i></a>
+          </td>
+      </tr>
+      </tbody>
+  </table>
 <div class="reveal" id="files-help" data-reveal>
     <h4><i class="fa fa-info-circle"></i> POST works too!</h4>
     <p>In some cases, the request header length is quite large which generates a <span class="api">400</span> HTTP
@@ -280,4 +302,353 @@
         <span aria-hidden="true">&times;</span>
     </button>
 </div>
+</details>
 
+<p>&nbsp</p>
+<h3>Learn more about the data in ArrayExpress</h3>
+
+<h4 id="magetab">MAGE-TAB metadata format</h4>
+<p>The MicroArray Gene Expression Tabular (MAGE-TAB) format has been developed and adopted by the functional genomics community as a means of representing and communicating data about a functional genomics experiment in a structured and standardised way <a href="http://europepmc.org/abstract/MED/17087822" target="_blank">(Rayner et al., 2006)</a>. It was designed for data collection and annotation, as well as for data exchange between tools and databases, including submission tools to public repositories such as ArrayExpress. The full <a href="http://fged.org/projects/mage-tab/" target="_blank">specification</a> outlines the format.</p>
+
+<h4 id="geo">GEO data</h4>
+<p>Some of the experiments and array designs in ArrayExpress have been imported from the <a href="http://www.ncbi.nlm.nih.gov/geo/">Gene Expression Omnibus</a> (GEO) at NCBI. This regular import has stopped in 2017.</p>
+<p> Imported experiments have ArrayExpress accession numbers in the format of E-GEOD-n, where n the same as the number in the original GEO series accession, e.g. GEO accession "GSE12345" would become "E-GEOD-12345" in ArrayExpress. Likewise, for array designs (or platforms), GEO accession "GPL567" would become A-GEOD-567 upon import.</p>
+
+<h4 id="accession_codes">Accession codes</h4>
+<p>Experiments and array designs in ArrayExpress are given unique accession numbers in the format of</p>
+<ul>
+    <li>E-XXXX-n for experiments</li>
+    <li>A-XXXX-n for array designs</li>
+</ul>
+<p>XXXX represents a four letter code and n is a number. E.g. E-MEXP-568, A-UHNC-18.</p>
+<p>The four letter code in the accession number indicates the data source. Many of the codes are no longer in active use, i.e. they are not used in accession numbers for new submissions, but remain valid. Note that some URLs are dead, or point to webpages which are out of maintenance, but included in the table below for completeness.
+<details>
+  <summary>Full list of four-letter codes</summary>
+    <table>
+      <thead>
+      <tr>
+          <th>Code</th>
+          <th>Source</th>
+          <th>URL</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+          <td>AFFY</td>
+          <td>Affymetrix</td>
+          <td><a href="http://www.affymetrix.com/">www.affymetrix.com</a></td>
+      </tr>
+      <tr>
+          <td>AFMX</td>
+          <td>Affymetrix data sets processed by an
+              EBI in-house script </td>
+          <td>&nbsp;</td>
+      </tr>
+      <tr>
+          <td>AGIL</td>
+          <td>Agilent</td>
+          <td><a href="http://www.agilent.com/">www.agilent.com</a></td>
+      </tr>
+      <tr>
+          <td>ATMX</td>
+          <td>Arabidopsis experiments and array
+              designs submitted through
+              the At-MIAMExpress submission tool</td>
+          <td>tool deprecated</td>
+      </tr>
+      <tr>
+          <td>BAIR</td>
+          <td>Biological Atlas of Insulin Resistance
+              (BAIR) project</td>
+          <td><a href="http://www.bair.org.uk/">www.bair.org.uk</a></td>
+      </tr>
+      <tr>
+          <td>BASE</td>
+          <td> BASE microarray data management tool</td>
+          <td><a href="http://base.thep.lu.se/">base.thep.lu.se</a></td>
+      </tr>
+      <tr>
+          <td>BIOD</td>
+          <td>BioDiscovery microarray data management
+              tool</td>
+          <td><a href="http://www.biodiscovery.com/">www.biodiscovery.com</a></td>
+      </tr>
+      <tr>
+          <td>BUGS</td>
+          <td>Bacterial Microarray Group at St
+              George's, University of
+              London (BuG@S)</td>
+          <td><a href="http://www.bugs.sgul.ac.uk/">www.bugs.sgul.ac.uk</a></td>
+      </tr>
+      <tr>
+          <td>CAGE</td>
+          <td>Compendium of Arabidopsis Gene
+              Expression plant developmental
+              time series project</td>
+          <td><a
+                  href="http://www.cagecompendium.org/index.htm">www.cagecompendium.org/index.htm</a>
+              and <a href="/microarray/cage">www.ebi.ac.uk/microarray/cage</a></td>
+      </tr>
+      <tr>
+          <td>CBIL</td>
+          <td>Computational Biology and Informatics
+              Laboratory at
+              University of Pennsylvania</td>
+          <td><a href="http://www.cbil.upenn.edu/">www.cbil.upenn.edu</a></td>
+      </tr>
+      <tr>
+          <td>DKFZ</td>
+          <td>German Cancer Research Center</td>
+          <td><a href="http://www.dkfz.de/">www.dkfz.de</a></td>
+      </tr>
+      <tr>
+          <td>DORD</td>
+          <td>DDBJ Omics Archive (DOR)</td>
+          <td><a href="http://trace.ddbj.nig.ac.jp/dor">http://trace.ddbj.nig.ac.jp/dor</a></td>
+      </tr>
+      <tr>
+          <td>EMBL</td>
+          <td>European Molecular Biology Laboratory</td>
+          <td><a href="http://www.embl.org/">www.embl.org</a></td>
+      </tr>
+      <tr>
+          <td>ERAD</td>
+          <td>European
+              Read Archive Data (pipeline submission from Wellcome Trust Sanger
+              Institute. "European Read Archive" is now renamed the "Sequence Read
+              Archive" (SRA) as part of <a href="http://www.insdc.org/">INSDC</a>)<br>
+          </td>
+          <td><a href="http://www.sanger.ac.uk">www.sanger.ac.uk</a><br>
+              <a href="http://nar.oxfordjournals.org/content/early/2010/11/08/nar.gkq1019.long">NAR article on the SRA</a></td>
+      </tr>
+      <tr>
+          <td>FLYC</td>
+          <td>FlyChip Microarray services, Cambridge
+              Systems Biology
+              Centre, UK</td>
+          <td><a href="http://www.flychip.org.uk/">www.flychip.org.uk</a></td>
+      </tr>
+      <tr>
+          <td>FPMI</td>
+          <td>Functional Pathogenomics of Mucosal
+              Immunity project</td>
+          <td><a
+                  href="http://www.pathogenomics.ca/fpmi">www.pathogenomics.ca/fpmi</a></td>
+      </tr>
+      <tr>
+          <td>GEAD</td>
+          <td>Genomic Expression Archive (GEA)</td>
+          <td><a href="https://www.ddbj.nig.ac.jp/gea/index-e.html">www.ddbj.nig.ac.jp/gea/</a></td>
+      </tr>
+      <tr>
+          <td>GEHB</td>
+          <td>GE Healthcare array designs </td>
+          <td><a href="http://www.gehealthcare.com/">www.gehealthcare.com</a></td>
+      </tr>
+      <tr>
+          <td>GEOD</td>
+          <td>NCBI Gene Expression Omnibus (GEO)</td>
+          <td><a
+                  href="http://www.ncbi.nlm.nih.gov/geo">www.ncbi.nlm.nih.gov/geo</a></td>
+      </tr>
+      <tr>
+          <td>GEUV</td>
+          <td>Genetic European Variation in Health and Disease (GEUVADIS), A European Medical Sequencing Consortium</td>
+          <td><a
+                  href="http://www.geuvadis.org/web/geuvadis/home">www.geuvadis.org/web/geuvadis/home</a>.</td>
+      </tr>
+      <tr>
+          <td>HCAD</td>
+          <td>Human Cell Atlas</td>
+          <td><a
+                  href="https://www.humancellatlas.org">www.humancellatlas.org</a></td>
+      </tr>
+      <tr>
+          <td>HGMP</td>
+          <td>Human Genome Mapping Project Resource
+              Centre (now closed)</td>
+          <td><a
+                  href="http://www.geneservice.co.uk/home">www.geneservice.co.uk/home</a></td>
+      </tr>
+      <tr>
+          <td>IPKG</td>
+          <td>Leibniz Institute of Plant Genetics and
+              Crop Plant Research
+              (IPK-Gatersleben)</td>
+          <td><a
+                  href="http://www.ipk-gatersleben.de/Internet">www.ipk-gatersleben.de/Internet</a></td>
+      </tr>
+      <tr>
+          <td>JCVI</td>
+          <td>J. Craig Venter Institute</td>
+          <td><a href="http://www.jcvi.org/">www.jcvi.org</a></td>
+      </tr>
+      <tr>
+          <td>JJRD</td>
+          <td>Johnson &amp; Johnson Pharmaceutical
+              Research and Development</td>
+          <td><a href="http://www.jnjpharmarnd.com/">www.jnjpharmarnd.com</a></td>
+      </tr>
+      <tr>
+          <td>LGCL</td>
+          <td>LGC Limited</td>
+          <td><a href="http://www.lgc.co.uk/">www.lgc.co.uk</a></td>
+      </tr>
+      <tr>
+          <td>MANP</td>
+          <td>Coding of experiment was manually
+              prepared by EBI staff</td>
+          <td>&nbsp;</td>
+      </tr>
+      <tr>
+          <td>MARS</td>
+          <td>Microarray Analysis and Retrieval
+              System (MARS) from Graz
+              University of Technology, Institute for Genomics and Bioinformatics</td>
+          <td><a href="http://genome.tugraz.at/">genome.tugraz.at</a></td>
+      </tr>
+      <tr>
+          <td>MAXD</td>
+          <td>University of Manchester, Micorarray
+              Group maxd software</td>
+          <td><a
+                  href="http://www.bioinf.manchester.ac.uk/microarray/maxd">www.bioinf.manchester.ac.uk/microarray/maxd</a></td>
+      </tr>
+      <tr>
+          <td>MEXP</td>
+          <td>EBI MIAMExpress webform submission tool (deprecated since July 2014)</td>
+          <td><a
+                  href="/miamexpress">www.ebi.ac.uk/miamexpress</a></td>
+      </tr>
+      <tr>
+          <td>MIMR</td>
+          <td>MiMiR data warehouse at the Microarray
+              Centre, Clinical
+              Sciences Centre, Medical Research Council</td>
+          <td><a href="http://www.csc.mrc.ac.uk/">www.csc.mrc.ac.uk</a></td>
+      </tr>
+      <tr>
+          <td>MNIA</td>
+          <td>Laboratory of Genetics, National
+              Institute on Aging, <br>
+              National Institutes of Health</td>
+          <td><a href="http://lgsun.grc.nia.nih.gov/">lgsun.grc.nia.nih.gov</a></td>
+      </tr>
+      <tr>
+          <td>MTAB</td>
+          <td>Experiments in <a href="http://fged.org/projects/miame/">MAGE-TAB format</a>, submitted via the MTAB spreadsheet submission tool (retired in September 2014), or via <a href="http://www.ebi.ac.uk/fg/annotare/login">Annotare</a></td>
+          <td><a
+                  href="/fg/annotare/login">http://www.ebi.ac.uk/fg/annotare/login</a></td>
+      </tr>
+      <tr>
+          <td>MUGN</td>
+          <td>Integrated Functional Genomics in
+              Mutant Mouse Models as
+              Tools to Investigate the Complexity of Human Immunological Disease
+              (MUGEN) project</td>
+          <td><a href="http://www.mugen-noe.org/">www.mugen-noe.org</a>
+              and <a href="/fg/mugen">www.ebi.ac.uk/fg/mugen</a></td>
+      </tr>
+      <tr>
+          <td>NASC</td>
+          <td>European Arabidopsis Stock Centre</td>
+          <td><a href="http://arabidopsis.info/">arabidopsis.info</a></td>
+      </tr>
+      <tr>
+          <td>NCMF</td>
+          <td>Netherlands Cancer Institute Central
+              Microarray Facility </td>
+          <td><a href="http://microarrays.nki.nl/">microarrays.nki.nl</a></td>
+      </tr>
+      <tr>
+          <td>NGEN</td>
+          <td>Nimblegen</td>
+          <td><a href="http://www.nimblegen.com/">www.nimblegen.com</a></td>
+      </tr>
+      <tr>
+          <td>RUBN</td>
+          <td>Gerry Rubin's lab</td>
+          <td><a
+                  href="http://www.hhmi.org/research/groupleaders/rubin.html">http://www.hhmi.org/research/groupleaders/rubin.html</a></td>
+      </tr>
+      <tr>
+          <td>RZPD</td>
+          <td>RZPD German Resource Center for Genome
+              Research (no long accessible) </td>
+          <td><a href="http://www.rzpd.de/">www.rzpd.de (old URL)</a></td>
+      </tr>
+      <tr>
+          <td>SGRP</td>
+          <td>Saccharomyces Genome Resequencing
+              Project , Wellcome Trust
+              Sanger Institute</td>
+          <td><a
+                  href="http://www.sanger.ac.uk/Teams/Team71/durbin/sgrp">www.sanger.ac.uk/Teams/Team71/durbin/sgrp</a></td>
+      </tr>
+      <tr>
+          <td>SMDB</td>
+          <td>Stanford Micorarray Database (moving to Princeton University, as of January 2013)</td>
+          <td><a
+                  href="http://smd.stanford.edu">http://smd.stanford.edu</a></td>
+      </tr>
+      <tr>
+          <td>SNGR</td>
+          <td>Wellcome Trust Sanger Institute</td>
+          <td><a href="http://www.sanger.ac.uk/">www.sanger.ac.uk</a></td>
+      </tr>
+      <tr>
+          <td>SYBR</td>
+          <td>Sybaris Project</td>
+          <td><a href="http://www.sybaris-fp7.eu/">http://www.sybaris-fp7.eu/</a></td>
+      </tr>
+      <tr>
+          <td>TABM</td>
+          <td>EBI tab2mage spreadsheet submission
+              tool (deprecated since January 2012)<br>
+          </td>
+          <td><a
+                  href="/cgi-bin/microarray/tab2mage.cgi">www.ebi.ac.uk/cgi-bin/microarray/tab2mage.cgi</a></td>
+      </tr>
+      <tr>
+          <td>TIGR</td>
+          <td>The Institute for Genomic Research (now
+              part of the J. Craig
+              Venter Institute)</td>
+          <td><a href="http://www.tigr.org/">www.tigr.org</a></td>
+      </tr>
+      <tr>
+          <td>TOXM</td>
+          <td>Toxicogenomics experiments </td>
+          <td>&nbsp;</td>
+      </tr>
+      <tr>
+          <td>UCON</td>
+          <td>The Hutchison/MRC Research Centre</td>
+          <td><a
+                  href="http://www.hutchison-mrc.cam.ac.uk/">www.hutchison-mrc.cam.ac.uk</a></td>
+      </tr>
+      <tr>
+          <td>UHNC</td>
+          <td>University Health Network Canada</td>
+          <td><a href="http://www.uhn.ca/">www.uhn.ca</a></td>
+      </tr>
+      <tr>
+          <td>UMCU</td>
+          <td>University Medical Center Utrecht</td>
+          <td><a href="http://www.umcutrecht.nl/zorg">www.umcutrecht.nl/zorg</a></td>
+      </tr>
+      <tr>
+          <td>WMIT</td>
+          <td>Whitehead Institute for Biomedical
+              Research/ Massachusetts
+              Institute of Technology</td>
+          <td><a href="http://www.wi.mit.edu/">www.wi.mit.edu</a></td>
+      </tr>
+      </tbody>
+    </table>
+</details>
+</p>
+
+<h4 id="esets">ExpressionSet R objects</h4>
+<p>For many ArrayExpress experiments, an "ExpressionSet" object (e.g. <a href="https://www.ebi.ac.uk/biostudies/files/E-MTAB-777/E-MTAB-777.eSet.r">E-MTAB-777.eSet.r</a>) is available to download for direct loading into <a href="http://www.r-project.org">R</a>.</p>
+<p>An ExpressionSet is the <i>de facto</i> object defined in the <a href="http://www.bioconductor.org">Bioconductor</a> <a href="http://www.bioconductor.org/packages/release/bioc/html/Biobase.html">Biobase</a> package for loading and manipulating microarray data in <a href="http://www.r-project.org/">R</a>. These objects are created using the <a href="http://www.bioconductor.org/packages/release/bioc/html/ArrayExpress.html">ArrayExpress R package</a> using default parameters. For each experiment, raw (un-normalized) data files are stored in the object as well as other metadata from its MAGE-TAB files, such as study, sample and gene metadata. Please refer to the package ArrayExpress package <a href="http://www.bioconductor.org/packages/release/bioc/vignettes/ArrayExpress/inst/doc/ArrayExpress.pdf">vignette</a> for more details.</p>


### PR DESCRIPTION
This is the first go at moving over help content from ArrayExpress to the BioStudies collection. 

In this PR I changed the following:

Created the sections:
- How to submit
- Programmatic access
- Learn more about our data

Moved the previous content for the API migration guide under "Programmatic access"
Copied over relevant bits from the AE help pages about the data in ArrayExpress and MAGE-TAB format
Moved long lists in expandable details sections. 