### PR TITLE
BIOSTD-247: Update RH3R collection facets (add organ/toxicity, rename, display fixes)

### DIFF
--- a/src/main/java/uk/ac/ebi/biostudies/api/util/parser/SimpleAttributeParser.java
+++ b/src/main/java/uk/ac/ebi/biostudies/api/util/parser/SimpleAttributeParser.java
@@ -24,8 +24,14 @@ public class SimpleAttributeParser extends AbstractParser {
         Object result= NA;
         String indexKey = indexEntry.get(Constants.IndexEntryAttributes.NAME).asText();
         try {
-            String title = StringUtils.replace(indexEntry.get(Constants.Fields.TITLE).asText(), "/", "\\/");
-            String newJPath = String.format(jpath, title);
+            String newJPath;
+            if (indexEntry.has(Constants.IndexEntryAttributes.JSON_PATH)) {
+                newJPath = indexEntry.get(Constants.IndexEntryAttributes.JSON_PATH).asText();
+            } else {
+                String title = StringUtils.replace(indexEntry.get(Constants.Fields.TITLE).asText(), "/", "\\/");
+                newJPath = String.format(jpath, title);
+            }
+
             List <String> resultData = jsonPathContext.read(newJPath);
             if(indexEntry.has(Constants.Facets.MATCH)) {
                 String match = indexEntry.get(Constants.Facets.MATCH).asText();

--- a/src/main/java/uk/ac/ebi/biostudies/service/impl/FacetServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/biostudies/service/impl/FacetServiceImpl.java
@@ -69,9 +69,13 @@ public class FacetServiceImpl implements FacetService {
             if (facet == null || !facet.get(Constants.IndexEntryAttributes.FIELD_TYPE).asText().equalsIgnoreCase(Constants.IndexEntryAttributes.FieldTypeValues.FACET))
                 continue;
             List<String> listSelectedValues = userSelectedDimValues.get(facet);
+            boolean mustLowerCase = true;
+            if (facet.has(Constants.IndexEntryAttributes.TO_LOWER_CASE)) {
+                mustLowerCase = facet.get(Constants.IndexEntryAttributes.TO_LOWER_CASE).asBoolean(true);
+            }
             if (listSelectedValues != null)
                 for (String value : listSelectedValues) {
-                    drillDownQuery.add(facet.get(Constants.IndexEntryAttributes.NAME).asText(), value.toLowerCase());
+                    drillDownQuery.add(facet.get(Constants.IndexEntryAttributes.NAME).asText(), mustLowerCase ? value.toLowerCase() : value);
                 }
         }
         return drillDownQuery;

--- a/src/main/java/uk/ac/ebi/biostudies/service/impl/IndexServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/biostudies/service/impl/IndexServiceImpl.java
@@ -508,13 +508,17 @@ public class IndexServiceImpl implements IndexService {
                 else
                     value = NA;
             }
+            boolean mustLowerCase = true;
+            if (facetConfig.has(Constants.IndexEntryAttributes.TO_LOWER_CASE)) {
+                mustLowerCase = facetConfig.get(Constants.IndexEntryAttributes.TO_LOWER_CASE).asBoolean(true);
+            }
             for (String subVal : org.apache.commons.lang3.StringUtils.split(value, Facets.DELIMITER)) {
                 if(subVal==null || subVal.trim().isEmpty() )
                     continue;
                 if (subVal.equalsIgnoreCase(NA) && facetConfig.has(IndexEntryAttributes.DEFAULT_VALUE)) {
                     subVal = facetConfig.get(IndexEntryAttributes.DEFAULT_VALUE).textValue();
                 }
-                doc.add(new FacetField(fieldName, subVal.trim().toLowerCase()));
+                doc.add(new FacetField(fieldName, mustLowerCase ? subVal.trim().toLowerCase() : subVal.trim()));
             }
         }
     }

--- a/src/main/resources/collection-fields.json
+++ b/src/main/resources/collection-fields.json
@@ -65,10 +65,12 @@
     { "name": "facet.eutoxrisk.project_part", "title": "Project part", "fieldType": "facet"}
   ],
   "rh3r": [
-    { "name": "facet.rh3r.wrk_pckg", "title": "Project part \\(Work package\\)", "fieldType": "facet", "match": "^([a-zA-Z0-9.]+)"},
-    { "name": "facet.rh3r.case_study", "title": "Project part \\(Case study\\)", "fieldType": "facet", "match": "^([a-zA-Z0-9.]+)"},
+    { "name": "facet.rh3r.wrk_pckg", "title": "Work package", "fieldType": "facet", "match": "^([a-zA-Z0-9.]+)", "parser": "SimpleAttributeParser", "jsonPath": "$.section.attributes[?(@.name=~ /Project part \\(Work package\\)/i)].value"},
+    { "name": "facet.rh3r.case_study", "title": "Case study", "fieldType": "facet", "match": "^([a-zA-Z0-9.]+)", "parser": "SimpleAttributeParser", "jsonPath": "$.section.attributes[?(@.name=~ /Project part \\(Case study\\)/i)].value"},
     { "name": "facet.rh3r.info_type", "title": "Type of information", "fieldType": "facet"},
-    { "name": "facet.rh3r.org", "title": "Organization", "jsonPath" : "$..sections[?(@.type=='Organization')].attributes[?(@.name=='Name' && @.value != null)].value","fieldType": "facet"}
+    { "name": "facet.rh3r.organ", "title": "Organ", "fieldType": "facet"},
+    { "name": "facet.rh3r.toxy_dom", "title": "Toxicity domain", "fieldType": "facet"},
+    { "name": "facet.rh3r.org", "title": "Organization", "jsonPath" : "$..sections[?(@.type=='Organization')].attributes[?(@.name=='Name' && @.value != null)].value", "fieldType": "facet", "toLowerCase": "false"}
   ],
   "public": [
     { "name": "access", "title": "", "fieldType": "tokenized_string", "jsonPath": "$.accessTags[?(@ =~ /[^{].*/i)] OR $.accessTags[?(@.size() > 0)].name", "analyzer": "AccessFieldAnalyzer", "parser": "AccessParser", "toLowerCase": "true"},


### PR DESCRIPTION
BIOSTD-247: Update RH3R collection facets (add organ/toxicity, rename, display fixes)

- Added new facets for "Organ" and "Toxicity domain" as Study attribute extracts.
- Renamed "Project part (Work package)" to "Work package" and "Project part (Case study)" to "Case study".
- Ensured "Organization" facet is displayed without lowercasing.
- Updated `collection-fields.json` to:
	- Add new facets and update existing ones with correct titles and explicit jsonPath.
	- Set `parser: SimpleAttributeParser` where needed.
	- Set `toLowerCase: false` for "Organization".
- Modified` SimpleAttributeParser` to accept a custom jsonPath.
- Updated `IndexServiceImpl.JsonDocumentIndexer#addFacet` to only lowercase facets if not explicitly disabled