### PR TITLE
keep your original data order in links table

### DIFF
--- a/src/main/webapp/js/detail/metadata.js
+++ b/src/main/webapp/js/detail/metadata.js
@@ -300,6 +300,7 @@ var Metadata = (function (_self) {
         linksTable = $("#link-list").DataTable({
             "lengthMenu": [[5, 10, 25, 50, 100], [5, 10, 25, 50, 100]],
             "dom": "rlftpi",
+            "order": [],
             "infoCallback": function( settings, start, end, max, total, out ) {
                 return (total== max) ? out : out +' <a class="section-button" id="clear-filter" onclick="Metadata.clearLinkFilter();return false;">' +
                     '<span class="fa-layers fa-fw">'


### PR DESCRIPTION
When a DataTable is created with no explicit "order" option, it sorts the table by the first column in ascending order right after rendering, regardless of the original data order in the HTML. This change disables initial sorting by adding an explicit "order": [] option in DataTable configuration